### PR TITLE
Load Gif From Rankings

### DIFF
--- a/src/components/GifItem.tsx
+++ b/src/components/GifItem.tsx
@@ -5,6 +5,7 @@ interface GifItemProps {
   title: string;
   url: string;
   rank?: number;
+  gif_id?: string;
   onSelect?: (id: string) => void; // Optional callback for selection
 }
 
@@ -30,16 +31,21 @@ interface GifItemProps {
  *
  * export default Example;
  *
- * @param id
- * @param title
- * @param url
- * @param onSelect
+ * @param id the gif_id (or for rank records -> the rank id )
+ * @param title the title of the gif
+ * @param url the url to load the gif
+ * @param gif_id the id of the gif (for rank records)
+ * @param rank the rank of the gif (optional)
+ * @param onSelect callback for gif selection
  * @constructor
  */
-const GifItem: React.FC<GifItemProps> = ({ id, title, url, rank, onSelect }) => {
+const GifItem: React.FC<GifItemProps> = ({ id, title, url, gif_id, rank, onSelect }) => {
   const handleClick = () => {
-    if (onSelect) {
+    if (onSelect && !rank) {
       onSelect(id);
+    }
+    if (onSelect && rank && gif_id) {
+      onSelect(gif_id)
     }
   };
 

--- a/src/components/GifRankings.tsx
+++ b/src/components/GifRankings.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import GifItem from './GifItem';
 
-interface Gif {
+interface GifRank {
   id: string;
+  gif_id: string;
   title: string;
   url: string;
   rank: number;
 }
 
 interface GifRankingsProps {
-  gifs: Gif[];
+  gifs: GifRank[];
   onGifSelect?: (id: string) => void;
 }
 
@@ -35,6 +36,7 @@ const GifRankings: React.FC<GifRankingsProps> = ({ gifs, onGifSelect }) => {
             title={gif.title}
             url={gif.url}
             rank={gif.rank}
+            gif_id={gif.gif_id}
             onSelect={onGifSelect}
           />
         </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,16 +1,32 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import SearchBar from '../components/SearchBar';
 import useFetchGifs from '../hooks/useFetchGifs';
 import SearchResults from "../components/SearchResults.tsx";
 import { Link } from 'react-router-dom';
 
 const MainLayout: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [query, setQuery] = useState<string>('');
   const { loading, fetchGifs } = useFetchGifs();
+
+  // Parse the search query from the URL on initial load
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const initialQuery = searchParams.get('query');
+    if (initialQuery) {
+      setQuery(initialQuery);
+      fetchGifs(initialQuery);
+    }
+  }, [location.search, fetchGifs]);
 
   const handleSearch = (searchTerm: string) => {
     setQuery(searchTerm);
     fetchGifs(searchTerm);
+
+    // Update the URL with the new search query
+    navigate(`?query=${encodeURIComponent(searchTerm)}`, { replace: false });
   };
 
   return (

--- a/src/pages/GifDetail.tsx
+++ b/src/pages/GifDetail.tsx
@@ -49,9 +49,6 @@ const GifDetails: React.FC = () => {
     <div className="gif-details">
       <h1>{gifDetails.title}</h1>
       <img src={gifDetails.preview_url} alt={gifDetails.title} className="gif-image" />
-      <p>
-        <strong>GIF ID:</strong> {gifDetails.id}
-      </p>
     </div>
   );
 };


### PR DESCRIPTION
This pull request fixes an issue with loading an individual Gif from rankings, which was sending the ranking id.

Also added query param for the search query, so that back is enabled. 